### PR TITLE
Did some changes in the database and tested it

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -1,0 +1,13 @@
+class BookingsController < ApplicationController
+  def new
+  end
+
+  def create
+  end
+
+  def index
+  end
+
+  def show
+  end
+end

--- a/app/controllers/offerings_controller.rb
+++ b/app/controllers/offerings_controller.rb
@@ -1,0 +1,22 @@
+class OfferingsController < ApplicationController
+  def index
+  end
+
+  def show
+  end
+
+  def new
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,4 @@
+class UsersController < ApplicationController
+  def show
+  end
+end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,4 +1,12 @@
 class Booking < ApplicationRecord
   belongs_to :user
   belongs_to :listing
+
+  # Define status as an enum (easier to read and write than strings)
+  enum status: {
+    pending: 'pending',
+    confirmed: 'confirmed',
+    canceled: 'canceled',
+    completed: 'completed'
+  }
 end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -9,4 +9,9 @@ class Booking < ApplicationRecord
     canceled: 'canceled',
     completed: 'completed'
   }
+
+  # Validations
+  validates :date_start, presence: true
+  validates :date_end, presence: true
+  validate :end_date_after_start_date
 end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -1,3 +1,4 @@
 class Listing < ApplicationRecord
   belongs_to :user
+  has_many :bookings
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+  has_many :listings, dependent: :destroy
+  has_many :bookings, dependent: :destroy
+  has_many :reviews, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/bookings/create.html.erb
+++ b/app/views/bookings/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Bookings#create</h1>
+<p>Find me in app/views/bookings/create.html.erb</p>

--- a/app/views/bookings/index.html.erb
+++ b/app/views/bookings/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Bookings#index</h1>
+<p>Find me in app/views/bookings/index.html.erb</p>

--- a/app/views/bookings/new.html.erb
+++ b/app/views/bookings/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Bookings#new</h1>
+<p>Find me in app/views/bookings/new.html.erb</p>

--- a/app/views/bookings/show.html.erb
+++ b/app/views/bookings/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Bookings#show</h1>
+<p>Find me in app/views/bookings/show.html.erb</p>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,0 +1,20 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= f.error_notification %>
+  <%= f.full_error :confirmation_token %>
+
+  <div class="form-inputs">
+    <%= f.input :email,
+                required: true,
+                autofocus: true,
+                value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
+                input_html: { autocomplete: "email" } %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit, "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @email %>!</p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+<% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,0 +1,27 @@
+<h2>Change your password</h2>
+
+<%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= f.error_notification %>
+
+  <%= f.input :reset_password_token, as: :hidden %>
+  <%= f.full_error :reset_password_token %>
+
+  <div class="form-inputs">
+    <%= f.input :password,
+                label: "New password",
+                required: true,
+                autofocus: true,
+                hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
+                input_html: { autocomplete: "new-password" } %>
+    <%= f.input :password_confirmation,
+                label: "Confirm your new password",
+                required: true,
+                input_html: { autocomplete: "new-password" } %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit, "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,18 @@
+<h2>Forgot your password?</h2>
+
+<%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
+    <%= f.input :email,
+                required: true,
+                autofocus: true,
+                input_html: { autocomplete: "email" } %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit, "Send me reset password instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,0 +1,35 @@
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
+    <%= f.input :email, required: true, autofocus: true %>
+
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
+    <% end %>
+
+    <%= f.input :password,
+                hint: "leave it blank if you don't want to change it",
+                required: false,
+                input_html: { autocomplete: "new-password" } %>
+    <%= f.input :password_confirmation,
+                required: false,
+                input_html: { autocomplete: "new-password" } %>
+    <%= f.input :current_password,
+                hint: "we need your current password to confirm your changes",
+                required: true,
+                input_html: { autocomplete: "current-password" } %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit, "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
+
+<%= link_to "Back", :back %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,25 @@
+<h2>Sign up</h2>
+
+<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
+    <%= f.input :email,
+                required: true,
+                autofocus: true,
+                input_html: { autocomplete: "email" }%>
+    <%= f.input :password,
+                required: true,
+                hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
+                input_html: { autocomplete: "new-password" } %>
+    <%= f.input :password_confirmation,
+                required: true,
+                input_html: { autocomplete: "new-password" } %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit, "Sign up" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,20 @@
+<h2>Log in</h2>
+
+<%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="form-inputs">
+    <%= f.input :email,
+                required: false,
+                autofocus: true,
+                input_html: { autocomplete: "email" } %>
+    <%= f.input :password,
+                required: false,
+                input_html: { autocomplete: "current-password" } %>
+    <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit, "Log in" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation" data-turbo-cache="false">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+  <% end %>
+<% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,0 +1,19 @@
+<h2>Resend unlock instructions</h2>
+
+<%= simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= f.error_notification %>
+  <%= f.full_error :unlock_token %>
+
+  <div class="form-inputs">
+    <%= f.input :email,
+                required: true,
+                autofocus: true,
+                input_html: { autocomplete: "email" } %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit, "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/offerings/create.html.erb
+++ b/app/views/offerings/create.html.erb
@@ -1,0 +1,2 @@
+<h1>Offerings#create</h1>
+<p>Find me in app/views/offerings/create.html.erb</p>

--- a/app/views/offerings/destroy.html.erb
+++ b/app/views/offerings/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>Offerings#destroy</h1>
+<p>Find me in app/views/offerings/destroy.html.erb</p>

--- a/app/views/offerings/edit.html.erb
+++ b/app/views/offerings/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Offerings#edit</h1>
+<p>Find me in app/views/offerings/edit.html.erb</p>

--- a/app/views/offerings/index.html.erb
+++ b/app/views/offerings/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Offerings#index</h1>
+<p>Find me in app/views/offerings/index.html.erb</p>

--- a/app/views/offerings/new.html.erb
+++ b/app/views/offerings/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Offerings#new</h1>
+<p>Find me in app/views/offerings/new.html.erb</p>

--- a/app/views/offerings/show.html.erb
+++ b/app/views/offerings/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Offerings#show</h1>
+<p>Find me in app/views/offerings/show.html.erb</p>

--- a/app/views/offerings/update.html.erb
+++ b/app/views/offerings/update.html.erb
@@ -1,0 +1,2 @@
+<h1>Offerings#update</h1>
+<p>Find me in app/views/offerings/update.html.erb</p>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,2 +1,2 @@
 <h1>Pages#home</h1>
-<p>Find me in app/views/pages/home.html.erb</p>
+<p>Hello from Rent a Politician!</p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Users#show</h1>
+<p>Find me in app/views/users/show.html.erb</p>

--- a/db/migrate/20250301035758_rename_type_column_in_listings.rb
+++ b/db/migrate/20250301035758_rename_type_column_in_listings.rb
@@ -1,0 +1,5 @@
+class RenameTypeColumnInListings < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :listings, :type, :type_of_event
+  end
+end

--- a/db/migrate/20250301040639_add_status_to_bookings.rb
+++ b/db/migrate/20250301040639_add_status_to_bookings.rb
@@ -1,0 +1,5 @@
+class AddStatusToBookings < ActiveRecord::Migration[7.1]
+  def change
+    add_column :bookings, :status, :string, default: "pending"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_02_27_185624) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_01_040639) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,13 +21,14 @@ ActiveRecord::Schema[7.1].define(version: 2025_02_27_185624) do
     t.bigint "listing_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "pending"
     t.index ["listing_id"], name: "index_bookings_on_listing_id"
     t.index ["user_id"], name: "index_bookings_on_user_id"
   end
 
   create_table "listings", force: :cascade do |t|
     t.string "name"
-    t.string "type"
+    t.string "type_of_event"
     t.decimal "price"
     t.string "location"
     t.datetime "availability_start"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,102 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+# db/seeds.rb
+# Clear existing data
+puts "Cleaning database..."
+Booking.destroy_all
+Listing.destroy_all
+User.destroy_all
+
+# Create users
+puts "Creating users..."
+user1 = User.create!(
+  email: "alice@example.com",
+  password: "password",
+  name: "Alice Smith"
+)
+
+user2 = User.create!(
+  email: "bob@example.com",
+  password: "password",
+  name: "Bob Johnson"
+)
+
+user3 = User.create!(
+  email: "politician1@example.com",
+  password: "password",
+  name: "Jane Politician"
+)
+
+user4 = User.create!(
+  email: "politician2@example.com",
+  password: "password",
+  name: "John Statesman"
+)
+
+# Create listings (politician profiles)
+puts "Creating listings..."
+listing1 = Listing.create!(
+  name: "Policy Discussion with Jane",
+  type_of_event: "Meeting",  # Changed from 'type' which is a reserved word in Ruby
+  price: 150.00,
+  location: "New York City",
+  availability_start: DateTime.now + 1.day,
+  availability_end: DateTime.now + 30.days,
+  picture: "https://randomuser.me/api/portraits/women/44.jpg",  # Placeholder URL
+  user: user3  # Jane Politician
+)
+
+listing2 = Listing.create!(
+  name: "Campaign Speech by John",
+  type_of_event: "Speech",  # Changed from 'type' which is a reserved word in Ruby
+  price: 500.00,
+  location: "Washington DC",
+  availability_start: DateTime.now + 2.days,
+  availability_end: DateTime.now + 60.days,
+  picture: "https://randomuser.me/api/portraits/men/32.jpg",  # Placeholder URL
+  user: user4  # John Statesman
+)
+
+listing3 = Listing.create!(
+  name: "Town Hall with Jane",
+  type_of_event: "Town Hall",  # Changed from 'type' which is a reserved word in Ruby
+  price: 300.00,
+  location: "Boston",
+  availability_start: DateTime.now + 5.days,
+  availability_end: DateTime.now + 45.days,
+  picture: "https://randomuser.me/api/portraits/women/44.jpg",  # Placeholder URL
+  user: user3  # Jane Politician
+)
+
+# Create bookings
+puts "Creating bookings..."
+booking1 = Booking.create!(
+  date_start: DateTime.now + 10.days + 14.hours,
+  date_end: DateTime.now + 10.days + 16.hours,
+  user: user1,  # Alice
+  listing: listing1,
+  status: "pending"  # You might need to add this column if not already present
+)
+
+booking2 = Booking.create!(
+  date_start: DateTime.now + 15.days + 10.hours,
+  date_end: DateTime.now + 15.days + 12.hours,
+  user: user2,  # Bob
+  listing: listing2,
+  status: "confirmed"  # You might need to add this column if not already present
+)
+
+booking3 = Booking.create!(
+  date_start: DateTime.now + 20.days + 15.hours,
+  date_end: DateTime.now + 20.days + 17.hours,
+  user: user1,  # Alice
+  listing: listing3,
+  status: "pending"  # You might need to add this column if not already present
+)
+
+puts "Finished seeding!"
+puts "Created #{User.count} users"
+puts "Created #{Listing.count} listings"
+puts "Created #{Booking.count} bookings"

--- a/test/controllers/bookings_controller_test.rb
+++ b/test/controllers/bookings_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class BookingsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get bookings_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get bookings_create_url
+    assert_response :success
+  end
+
+  test "should get index" do
+    get bookings_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get bookings_show_url
+    assert_response :success
+  end
+end

--- a/test/controllers/offerings_controller_test.rb
+++ b/test/controllers/offerings_controller_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class OfferingsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get offerings_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get offerings_show_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get offerings_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get offerings_create_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get offerings_edit_url
+    assert_response :success
+  end
+
+  test "should get update" do
+    get offerings_update_url
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get offerings_destroy_url
+    assert_response :success
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get users_show_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Add status column to Bookings model and implement enum functionality

This PR changes the Booking model to include a status column with enum support for tracking booking states (pending, confirmed, canceled, completed). Also fixes associations between User, Listing, and Booking models that were broken during the earlier table rename from 'offering' to 'listing'. 

I also created a seed file, and tested it, which led me to these changes. The final test was succesful.